### PR TITLE
Add option to enter username and password

### DIFF
--- a/Tasks/JBossDeployer/Tests/L0.ts
+++ b/Tasks/JBossDeployer/Tests/L0.ts
@@ -81,7 +81,7 @@ describe('jbossdeployer L0 Suite', function () {
         done();
     });
 
-    it('check if jbossdeployer fails without an username', (done: MochaDone) => {
+    it('check if jbossdeployer fails without a username in service endpoint definition', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0checkUsername.js');
@@ -93,10 +93,34 @@ describe('jbossdeployer L0 Suite', function () {
         done();
     });
 
-    it('check if jbossdeployer fails without a password', (done: MochaDone) => {
+    it('check if jbossdeployer fails without a password in service endpoint definition', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0checkPassword.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
+    it('check if jbossdeployer fails without a username defined', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0FailUsername.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
+    it('check if jbossdeployer fails without a password defined', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0FailPassword.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();

--- a/Tasks/JBossDeployer/Tests/L0FailPassword.ts
+++ b/Tasks/JBossDeployer/Tests/L0FailPassword.ts
@@ -6,12 +6,9 @@ import fs = require('fs');
 let taskPath = path.join(__dirname, '..', 'jbossdeployer.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
-process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
-// process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
-
-tmr.setInput('credsType', 'serviceEndpoint');
-tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
+tmr.setInput('credsType', 'inputs');
+tmr.setInput('jbossServerUrl', 'http://jboss.test:9090/testurl');
+tmr.setInput('jbossManagementUser', 'user1');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');
 tmr.setInput('disabled', 'true');

--- a/Tasks/JBossDeployer/Tests/L0FailUsername.ts
+++ b/Tasks/JBossDeployer/Tests/L0FailUsername.ts
@@ -6,12 +6,9 @@ import fs = require('fs');
 let taskPath = path.join(__dirname, '..', 'jbossdeployer.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
-process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
-// process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
-
-tmr.setInput('credsType', 'serviceEndpoint');
-tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
+tmr.setInput('credsType', 'inputs');
+tmr.setInput('jbossServerUrl', 'http://jboss.test:9090/testurl');
+tmr.setInput('jbossPassword', 'Password');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');
 tmr.setInput('disabled', 'true');

--- a/Tasks/JBossDeployer/Tests/L0checkIfFailWork.ts
+++ b/Tasks/JBossDeployer/Tests/L0checkIfFailWork.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');

--- a/Tasks/JBossDeployer/Tests/L0checkUsername.ts
+++ b/Tasks/JBossDeployer/Tests/L0checkUsername.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 // process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');

--- a/Tasks/JBossDeployer/Tests/L0runsJBossDeployerList.ts
+++ b/Tasks/JBossDeployer/Tests/L0runsJBossDeployerList.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');

--- a/Tasks/JBossDeployer/Tests/L0runsJBossDeployerMultipleList.ts
+++ b/Tasks/JBossDeployer/Tests/L0runsJBossDeployerMultipleList.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');

--- a/Tasks/JBossDeployer/Tests/L0runsJBossDeployerServer.ts
+++ b/Tasks/JBossDeployer/Tests/L0runsJBossDeployerServer.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('file', 'mock_file');
 tmr.setInput('force', 'true');

--- a/Tasks/JBossDeployer/task.json
+++ b/Tasks/JBossDeployer/task.json
@@ -69,6 +69,7 @@
         "label": "Password",
         "defaultValue": "",
         "required": true,
+        "helpMarkDown": "Enter the JBoss management user password. Use a new build variable with its lock enabled on the Variables tab to encrypt this value.",
         "visibleRule": "credsType = inputs"
       },
       {

--- a/Tasks/JBossDeployer/task.json
+++ b/Tasks/JBossDeployer/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 0, 
+        "Minor": 112, 
         "Patch": 0 
     },
     "groups": [
@@ -26,12 +26,50 @@
     "instanceNameFormat": "deploy $(file)",
     "inputs": [
       {
+        "name": "credsType",
+        "type": "pickList",
+        "label": "Authentication Method",
+        "defaultValue": "serviceEndpoint",
+        "required": true,
+        "helpMarkDown": "Use JBoss and WildFly service endpoint connection or enter connection credentials.",
+        "options": {
+            "serviceEndpoint": "JBoss and WildFly Connection",
+            "inputs": "Credentials"
+        }
+      },
+      {
         "name": "jbossEndpoint",
         "type": "connectedService:jbosseapwildflyendpoint",
         "label": "JBoss EAP/WildFly Endpoint",
         "defaultValue": "",
         "required": true,
-        "helpMarkDown": "Service endpoint for your JBoss EAP 7 / WildFly 8+ instance."
+        "helpMarkDown": "Service endpoint for your JBoss EAP 7 / WildFly 8+ instance.",
+        "visibleRule": "credsType = serviceEndpoint"
+      },
+      {
+        "name": "jbossServerUrl",
+        "type": "string",
+        "label": "JBoss EAP/WildFly Server URL",
+        "defaultValue": "",
+        "required": true,
+        "helpMarkDown": "URL for HTTP Management endpoint.",
+        "visibleRule": "credsType = inputs"
+      },
+      {
+        "name": "jbossManagementUser",
+        "type": "string",
+        "label": "Management User",
+        "defaultValue": "",
+        "required": true,
+        "visibleRule": "credsType = inputs"
+      },
+      {
+        "name": "jbossPassword",
+        "type": "string",
+        "label": "Password",
+        "defaultValue": "",
+        "required": true,
+        "visibleRule": "credsType = inputs"
       },
       {
         "name": "file",

--- a/Tasks/JBossManagementCLI/Tests/L0.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0.ts
@@ -64,7 +64,7 @@ describe('jbossmanagementcli L0 Suite', function () {
         done();
     });
 
-    it('check if it fails without an username', (done: MochaDone) => {
+    it('check if it fails without a username defined in service endpoint', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0checkUsername.js');
@@ -76,10 +76,34 @@ describe('jbossmanagementcli L0 Suite', function () {
         done();
     });
 
-    it('check if it fails without a password', (done: MochaDone) => {
+    it('check if it fails without a password defined in a service endpoint', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, 'L0checkPassword.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
+    it('check if jbossdeployer fails without a username defined', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0FailUsername.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.failed, 'task should have failed');
+
+        done();
+    });
+
+    it('check if jbossdeployer fails without a password defined', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, 'L0FailPassword.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();

--- a/Tasks/JBossManagementCLI/Tests/L0FailPassword.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0FailPassword.ts
@@ -1,0 +1,14 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'jbossmanagementcli.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('credsType', 'inputs');
+tmr.setInput('jbossServerUrl', 'http://jboss.test:9090/testurl');
+tmr.setInput('jbossManagementUser', 'user1');
+tmr.setInput('commands', 'mock_command1');
+
+tmr.run();

--- a/Tasks/JBossManagementCLI/Tests/L0FailUsername.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0FailUsername.ts
@@ -1,0 +1,14 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'jbossmanagementcli.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('credsType', 'inputs');
+tmr.setInput('jbossServerUrl', 'http://jboss.test:9090/testurl');
+tmr.setInput('jbossPassword', 'password');
+tmr.setInput('commands', 'mock_command1');
+
+tmr.run();

--- a/Tasks/JBossManagementCLI/Tests/L0checkIfFailWork.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0checkIfFailWork.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('commands', 'mock_command1');
 

--- a/Tasks/JBossManagementCLI/Tests/L0checkPassword.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0checkPassword.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 //process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('commands', 'mock_command1');
 

--- a/Tasks/JBossManagementCLI/Tests/L0checkUsername.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0checkUsername.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 //process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('commands', 'mock_command1');
 

--- a/Tasks/JBossManagementCLI/Tests/L0checkcommands.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0checkcommands.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('commands', 'mock_command1\nmock_command2\nmock_command3');
 

--- a/Tasks/JBossManagementCLI/Tests/L0runsJBossCli.ts
+++ b/Tasks/JBossManagementCLI/Tests/L0runsJBossCli.ts
@@ -10,6 +10,7 @@ process.env["ENDPOINT_URL_mock_jbossEndpoint"] = "https://example.test/v0.1";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_USERNAME"] = "test_username";
 process.env["ENDPOINT_AUTH_PARAMETER_mock_jbossEndpoint_PASSWORD"] = "test_password";
 
+tmr.setInput('credsType', 'serviceEndpoint');
 tmr.setInput('jbossEndpoint', 'mock_jbossEndpoint');
 tmr.setInput('commands', 'mock_command1');
 

--- a/Tasks/JBossManagementCLI/task.json
+++ b/Tasks/JBossManagementCLI/task.json
@@ -62,6 +62,7 @@
         "label": "Password",
         "defaultValue": "",
         "required": true,
+        "helpMarkDown": "Enter the JBoss management user password. Use a new build variable with its lock enabled on the Variables tab to encrypt this value.",
         "visibleRule": "credsType = inputs"
       },
       {

--- a/Tasks/JBossManagementCLI/task.json
+++ b/Tasks/JBossManagementCLI/task.json
@@ -13,18 +13,56 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 0,
+        "Minor": 112,
         "Patch": 0 
     },
     "instanceNameFormat": "Running management commands.",
     "inputs": [
+      {
+        "name": "credsType",
+        "type": "pickList",
+        "label": "Authentication Method",
+        "defaultValue": "serviceEndpoint",
+        "required": true,
+        "helpMarkDown": "Use JBoss and WildFly service endpoint connection or enter connection credentials.",
+        "options": {
+            "serviceEndpoint": "JBoss and WildFly Connection",
+            "inputs": "Credentials"
+        }
+      },
       {
         "name": "jbossEndpoint",
         "type": "connectedService:jbosseapwildflyendpoint",
         "label": "JBoss EAP/WildFly Endpoint",
         "defaultValue": "",
         "required": true,
-        "helpMarkDown": "Service endpoint for your JBoss EAP 7 / WildFly 8+ instance."
+        "helpMarkDown": "Service endpoint for your JBoss EAP 7 / WildFly 8+ instance.",
+        "visibleRule": "credsType = serviceEndpoint"
+      },
+      {
+        "name": "jbossServerUrl",
+        "type": "string",
+        "label": "JBoss EAP/WildFly Server URL",
+        "defaultValue": "",
+        "required": true,
+        "helpMarkDown": "URL for HTTP Management endpoint.",
+        "visibleRule": "credsType = inputs"
+      },
+      {
+        "name": "jbossManagementUser",
+        "type": "string",
+        "label": "Management User",
+        "defaultValue": "",
+        "required": true,
+        "visibleRule": "credsType = inputs"
+      },
+      {
+        "name": "jbossPassword",
+        "type": "string",
+        "label": "Password",
+        "defaultValue": "",
+        "required": true,
+        "visibleRule": "credsType = inputs"
       },
       {
         "name": "commands",

--- a/Tasks/extension-manifest.json
+++ b/Tasks/extension-manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "jboss-wildfly-management-extension",
     "name": "JBoss and WildFly",
-    "version": "0.1.0",
+    "version": "0.112.0",
     "publisher": "ms-vsts",
     "description": "Manage and deploy your WAR and EAR files to JBoss EAP 7 and WildFly 8+ instance.",
     "public": true,


### PR DESCRIPTION
TFS 2015 does not support the new Service Endpoint extension framework hence the service endpoint type defined in the extension manifest does not show up on the list.  

Add options to manually override the connection strings from the task itself.  

Enhancement for #5.