### PR TITLE
support https + support OpenJDK

### DIFF
--- a/jbosslibs/pom.xml
+++ b/jbosslibs/pom.xml
@@ -32,6 +32,12 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-cli</artifactId>
             <version>8.2.1.Final</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>sun.jdk</groupId>
+                    <artifactId>jconsole</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/jbosslibs/src/main/java/com/microsoft/alm/Driver.java
+++ b/jbosslibs/src/main/java/com/microsoft/alm/Driver.java
@@ -47,8 +47,13 @@ public class Driver {
             logger.info("Port not specified, default to 9990");
             port = 9990;
         }
-
-        cli.connect(hostname, port, this.credentials.username, this.credentials.getPassword());
+        if (server.getScheme().equalsIgnoreCase("https")) {
+            logger.info("protocol: https");
+            cli.connect("https-remoting", hostname, port, this.credentials.username, this.credentials.getPassword());
+        }
+        else {    
+            cli.connect(hostname, port, this.credentials.username, this.credentials.getPassword());
+        }
     }
 
     /**


### PR DESCRIPTION
to support https-remoting protocol we should use a different CLI.connect() overload method #9
to support OpenJDK #18